### PR TITLE
Add Three.js-based photography portfolio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# photography-portfolio-site
+# Photography Portfolio Site
+
+This project showcases a simple Three.js-powered photography portfolio inspired by Henry Heffernan's website. Open `index.html` in a browser to explore the images in 3D space.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Photography Portfolio</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <canvas id="bg"></canvas>
+  <div id="overlay">
+    <h1>Photography Portfolio</h1>
+    <p>Scroll to explore.</p>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,57 @@
+const scene = new THREE.Scene();
+
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+
+const renderer = new THREE.WebGLRenderer({
+  canvas: document.getElementById('bg'),
+  antialias: true
+});
+renderer.setSize(window.innerWidth, window.innerHeight);
+
+const loader = new THREE.TextureLoader();
+const imageUrls = [
+  'https://images.unsplash.com/photo-1504208434309-cb69f4fe52b0?auto=format&w=800',
+  'https://images.unsplash.com/photo-1472214103451-9374bd1c798e?auto=format&w=800',
+  'https://images.unsplash.com/photo-1519681393784-d120267933ba?auto=format&w=800',
+  'https://images.unsplash.com/photo-1507149833265-60c372daea22?auto=format&w=800'
+];
+
+const spacing = 5;
+imageUrls.forEach((url, i) => {
+  loader.load(url, texture => {
+    const geometry = new THREE.PlaneGeometry(4, 3);
+    const material = new THREE.MeshBasicMaterial({ map: texture });
+    const plane = new THREE.Mesh(geometry, material);
+    plane.position.z = -i * spacing;
+    plane.position.x = (Math.random() - 0.5) * 2;
+    plane.position.y = (Math.random() - 0.5) * 2;
+    scene.add(plane);
+  });
+});
+
+camera.position.z = 5;
+
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+window.addEventListener('resize', onWindowResize);
+
+let scrollY = 0;
+window.addEventListener('wheel', event => {
+  scrollY += event.deltaY * 0.002;
+  camera.position.z = 5 + scrollY;
+});
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+
+animate();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "photography-portfolio-site",
+  "version": "1.0.0",
+  "description": "A Three.js photography portfolio site inspired by Henry Heffernan",
+  "scripts": {
+    "test": "echo 'No tests specified'"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,18 @@
+body {
+  margin: 0;
+  overflow: hidden;
+  background: #000;
+}
+
+#overlay {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  color: #fff;
+  font-family: sans-serif;
+  z-index: 1;
+}
+
+canvas {
+  display: block;
+}


### PR DESCRIPTION
## Summary
- Build Three.js-powered gallery displaying images in 3D space with scroll navigation
- Style overlay instructions and full-screen canvas
- Document how to launch the portfolio site

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e691173208331a91887108874f9d3