### PR TITLE
Add horizontal scrolling gallery with zoom

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,6 +6,7 @@ const camera = new THREE.PerspectiveCamera(
   0.1,
   1000
 );
+camera.position.z = 5;
 
 const renderer = new THREE.WebGLRenderer({
   canvas: document.getElementById('bg'),
@@ -21,20 +22,20 @@ const imageUrls = [
   'https://images.unsplash.com/photo-1507149833265-60c372daea22?auto=format&w=800'
 ];
 
-const spacing = 5;
+const spacing = 8;
+const planes = [];
+
 imageUrls.forEach((url, i) => {
   loader.load(url, texture => {
     const geometry = new THREE.PlaneGeometry(4, 3);
     const material = new THREE.MeshBasicMaterial({ map: texture });
     const plane = new THREE.Mesh(geometry, material);
-    plane.position.z = -i * spacing;
-    plane.position.x = (Math.random() - 0.5) * 2;
-    plane.position.y = (Math.random() - 0.5) * 2;
+    plane.userData.baseX = i * spacing;
+    plane.position.x = plane.userData.baseX;
     scene.add(plane);
+    planes.push(plane);
   });
 });
-
-camera.position.z = 5;
 
 function onWindowResize() {
   camera.aspect = window.innerWidth / window.innerHeight;
@@ -43,14 +44,26 @@ function onWindowResize() {
 }
 window.addEventListener('resize', onWindowResize);
 
-let scrollY = 0;
+let scrollOffset = 0;
 window.addEventListener('wheel', event => {
-  scrollY += event.deltaY * 0.002;
-  camera.position.z = 5 + scrollY;
+  scrollOffset += event.deltaY * 0.005;
 });
 
 function animate() {
   requestAnimationFrame(animate);
+
+  planes.forEach(plane => {
+    const x = plane.userData.baseX - scrollOffset;
+    plane.position.x = x;
+
+    const distanceFromCenter = Math.abs(x);
+    const closeness = Math.max(0, 1 - distanceFromCenter / spacing);
+
+    plane.position.z = closeness * 2;
+    const scale = 1 + closeness * 0.5;
+    plane.scale.set(scale, scale, 1);
+  });
+
   renderer.render(scene, camera);
 }
 


### PR DESCRIPTION
## Summary
- replace depth scrolling with horizontal gallery motion
- zoom and position images closer when centered

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e6c2c5abc8331ab32e312c9934e6e